### PR TITLE
Make code block language detection case-insensitive

### DIFF
--- a/bin/bundown.ts
+++ b/bin/bundown.ts
@@ -24,7 +24,7 @@ function parse(markdown: string) {
         break
       case 'code-lang':
         if (markdown[j] === '\n') {
-          let language = block.language.split(/\s+/)[0]
+          let language = block.language.split(/\s+/)[0].toLowerCase()
           switch (language) {
             case 'ts':
               language = 'typescript'


### PR DESCRIPTION
I like to capitalise the language name of markdown code blocks. However, doing so prevents Bundown from recognising the language. This pull request enables Bundown to recognise arbitrarily capitalised language names by converting them to lowercase.